### PR TITLE
feat(profiling): automatic datasource profiling for search index datasources

### DIFF
--- a/tests/integration/datasource/test_search_datasource.py
+++ b/tests/integration/datasource/test_search_datasource.py
@@ -152,3 +152,29 @@ class TestSQLDatasourceQueries:
         indices = opensearch_datasource.query_get_index_metadata()
 
         assert INDEX_NAME in indices
+
+    def test_should_return_numeric_profile(
+        self, opensearch_datasource: OpenSearchSearchIndexDataSource
+    ):
+        profile = opensearch_datasource.profiling_search_aggregates_numeric(
+            INDEX_NAME, "age"
+        )
+
+        assert profile["min"] == 35
+        assert profile["max"] == 1500
+        assert profile["avg"] == 345
+        assert profile["sum"] == 1725
+        assert profile["distinct_count"] == 5
+        assert profile["missing_count"] == 0
+
+    def test_should_return_text_profile(
+        self, opensearch_datasource: OpenSearchSearchIndexDataSource
+    ):
+        profile = opensearch_datasource.profiling_search_aggregates_string(
+            INDEX_NAME, "name"
+        )
+        assert profile["distinct_count"] == 5
+        assert profile["missing_count"] == 0
+        assert profile["max_length"] == 15
+        assert profile["min_length"] == 4
+        assert profile["avg_length"] == 9.2


### PR DESCRIPTION
### Fixes/Implements #34

## Description
- Querying profiling for numeric & text fields in search index datasources.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Locally Tested
