### PR TITLE
docs: fix the issue link

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ For additional information and help, you can use one of these channels:
 
 :raised_hands: We greatly appreciate contributions - be it’s a bug fix, new feature, or documentations!
 
-Check out the [contributions guide](https://github.com/waterdipai/datachecks/blob/main/CONTRIBUTING.md) and [open issues](https://github.com/waterdipai/datachceks/issues).
+Check out the [contributions guide](https://github.com/waterdipai/datachecks/blob/main/CONTRIBUTING.md) and [open issues](https://github.com/waterdipai/datachecks/issues).
 
 **Datachecks contributors: :blue_heart:**
 


### PR DESCRIPTION
### Fixes/Documentation #

## Description

Fixes line 107 that indicates access to the access link as issues from https://github.com/waterdipai/datachceks/issues to https://github.com/waterdipai/datachecks/issues.
