### PR TITLE
fix(metrics): round function in average and variance metric

### DIFF
--- a/datachecks/core/datasource/sql_datasource.py
+++ b/datachecks/core/datasource/sql_datasource.py
@@ -124,11 +124,11 @@ class SQLDataSource(DataSource):
         :return:
         """
         qualified_table_name = self.qualified_table_name(table)
-        query = "SELECT ROUND(AVG({}), 2) FROM {}".format(field, qualified_table_name)
+        query = "SELECT AVG({}) FROM {}".format(field, qualified_table_name)
         if filters:
             query += " WHERE {}".format(filters)
 
-        return self.connection.execute(text(query)).fetchone()[0]
+        return round(self.connection.execute(text(query)).fetchone()[0], 2)
 
     def query_get_variance(self, table: str, field: str, filters: str = None) -> int:
         """
@@ -139,13 +139,11 @@ class SQLDataSource(DataSource):
         :return:
         """
         qualified_table_name = self.qualified_table_name(table)
-        query = "SELECT ROUND(VAR_SAMP({}),2) FROM {}".format(
-            field, qualified_table_name
-        )
+        query = "SELECT VAR_SAMP({}) FROM {}".format(field, qualified_table_name)
         if filters:
             query += " WHERE {}".format(filters)
 
-        return self.connection.execute(text(query)).fetchone()[0]
+        return round(self.connection.execute(text(query)).fetchone()[0], 2)
 
     def query_get_null_count(self, table: str, field: str, filters: str = None) -> int:
         """

--- a/tests/integration/test_databases_availability.py
+++ b/tests/integration/test_databases_availability.py
@@ -18,22 +18,3 @@ from datachecks.core.common.models.configuration import (
     DataSourceConnectionConfiguration,
 )
 from tests.utils import create_opensearch_client, create_postgres_connection
-
-
-@pytest.mark.usefixtures("opensearch_client_configuration")
-def test_opensearch_available(
-    opensearch_client_configuration,
-):
-    client = create_opensearch_client(opensearch_client_configuration)
-    assert client.ping()
-    client.close()
-
-
-@pytest.mark.usefixtures("pgsql_connection_configuration")
-def test_pgsql_available(
-    pgsql_connection_configuration: DataSourceConnectionConfiguration,
-):
-    psql_connection = create_postgres_connection(pgsql_connection_configuration)
-
-    assert psql_connection.execute(text("SELECT 1")).fetchone()[0] == 1
-    psql_connection.close()


### PR DESCRIPTION
### Fixes/Implements #89 

## Description
Usage of round function average and variance, is rendered unusable in Postgres SQL.
Summary Goes here.

## Type of change

Delete irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Locally Tested
