### PR TITLE
fix(dashboard): type decimal is not json serializable in html report generation

### DIFF
--- a/datachecks/report/dashboard.py
+++ b/datachecks/report/dashboard.py
@@ -192,7 +192,7 @@ class DashboardInfoBuilder:
                 metric_name=metric.tags.get("metric_name"),
                 data_source=metric.data_source,
                 metric_type=metric.metric_type,
-                metric_value=metric.value,
+                metric_value=f"{metric.value:.2f}",
                 is_valid=metric.is_valid,
                 reason=metric.reason,
             ).get_dict()

--- a/datachecks/report/models.py
+++ b/datachecks/report/models.py
@@ -42,7 +42,7 @@ class MetricRow:
     data_source: str
     metric_type: str
     is_valid: bool
-    metric_value: float
+    metric_value: str
     reason: str
 
     def get_dict(self):


### PR DESCRIPTION
### Fixes/Implements #128

## Description
Generating HTML report at datachecks_report.html
Failed to run datachecks inspection: Object of type Decimal is not JSON serializable 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Locally Tested
