### PR TITLE
Condition check for schema being none added 

### DIFF
--- a/datachecks/integrations/databases/postgres.py
+++ b/datachecks/integrations/databases/postgres.py
@@ -39,11 +39,17 @@ class PostgresDataSource(SQLDataSource):
                 database=self.data_connection.get("database"),
             )
             schema = self.data_connection.get("schema")
-            engine = create_engine(
-                url,
-                connect_args={"options": f"-csearch_path={schema}"},
-                isolation_level="AUTOCOMMIT",
-            )
+            if schema is None:
+                engine = create_engine(
+                    url,
+                    isolation_level="AUTOCOMMIT",
+                )
+            else:
+                engine = create_engine(
+                    url,
+                    connect_args={"options": f"-csearch_path={schema}"},
+                    isolation_level="AUTOCOMMIT",
+                )
             self.connection = engine.connect()
             return self.connection
         except Exception as e:


### PR DESCRIPTION
### Fixes/Implements #

## Description

A condition check has been implemented to check if schema is `None`, if it is none then it is passed into create_engine function from sqlalchemy in postgres.py database integration. It precents the issue #136 from happening.

## Type of change

Delete irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Locally Tested