### PR TITLE
duplication check logic for metric name implemented

### DIFF
--- a/datachecks/core/configuration/configuration_parser.py
+++ b/datachecks/core/configuration/configuration_parser.py
@@ -159,6 +159,16 @@ def parse_metric_configurations(
 ) -> Dict[str, MetricConfiguration]:
     metric_configurations: Dict[str, MetricConfiguration] = {}
 
+    metric_names = [
+        metric_yaml_configuration["name"]
+        for metric_yaml_configuration in metric_yaml_configurations
+    ]
+
+    if len(metric_names) != len(set(metric_names)):
+        raise DataChecksConfigurationError(
+            f"Duplicate metric names found in configuration: {metric_names}"
+        )
+
     for metric_yaml_configuration in metric_yaml_configurations:
         metric_type = MetricsType(metric_yaml_configuration["metric_type"].lower())
 


### PR DESCRIPTION
### Fixes/Implements #

## Description

Previously there was no duplication check logic implemented for metric name, as described in the issue #106, so in this pull request I have added a duplication check for `metric_name` in `parse_metric_configurations()` function, so if there is any duplicate metric name present in the configuration file, it will raise a `DataCheckConfigurationError`

![image](https://github.com/waterdipai/datachecks/assets/71203637/6bee6cbc-5fb8-4e1c-9c12-17a1a767b1f1)
![image](https://github.com/waterdipai/datachecks/assets/71203637/c7a6ec74-e549-446c-b6c1-4cef65028b98)

I have tested it with the following `config.yaml` file
```yaml
data_sources:
  - name: postgres
    type: postgres
    connection:
      host: 127.0.0.1
      port: 5432
      username: postgres
      password: password
      database: postgres
      schema: public
metrics:
  - name: count_of_products
    metric_type: row_count
    resource: postgres.products
    validation:
      threshold: "> 0 & < 1000"
  - name: count_of_products
    metric_type: row_count
    resource: postgres.products
    validation:
      threshold: "> 0 & < 500"
  - name: max_product_price_in_india
    metric_type: max
    resource: postgres.products.price
    filters:
      where: "country_code = 'IN'"
    validation:
      threshold: "< 190"
```

## Type of change

Delete irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Locally Tested