### PR TITLE
fix: duplicate datasource name throws error

### DIFF
--- a/datachecks/core/configuration/configuration_parser.py
+++ b/datachecks/core/configuration/configuration_parser.py
@@ -48,6 +48,15 @@ CONDITION_TYPE_MAPPING = {
 def parse_data_source_yaml_configurations(
     data_source_yaml_configurations: List[dict],
 ) -> Dict[str, DataSourceConfiguration]:
+    data_source_names = [
+        data_source["name"] for data_source in data_source_yaml_configurations
+    ]
+
+    if len(data_source_names) != len(set(data_source_names)):
+        raise DataChecksConfigurationError(
+            f"Duplicate data source names found in configuration {data_source_names}"
+        )
+
     data_source_configurations: Dict[str, DataSourceConfiguration] = {}
     for data_source_yaml_configuration in data_source_yaml_configurations:
         name_ = data_source_yaml_configuration["name"]


### PR DESCRIPTION
### Fixes/Implements #

## Description

Previously there was no duplication check logic implemented for metric name, as described in the issue https://github.com/waterdipai/datachecks/issues/105, so in this pull request I have added a duplication check for `data_source_names` in `parse_data_source_yaml_configurations()` function, so if there is any duplicate metric name present in the configuration file, it will raise a `DataCheckConfigurationError`

![image](https://github.com/waterdipai/datachecks/assets/71203637/8224a147-ee52-4946-9b25-522f5c9154ab)
![image](https://github.com/waterdipai/datachecks/assets/71203637/3874d41c-d005-4563-a6d8-0da84543b6d1)

I have tested it with the following `config.yaml` file

```yaml
data_sources:
  - name: search_datastore
    type: opensearch
    connection:
      host: 127.0.0.1
      port: 9205
      username: !ENV ${OS_USER}
      password: !ENV ${OS_PASS}
  - name: search_datastore
    type: postgres
    connection:
      host: 127.0.0.1
      port: 5432
      username: !ENV ${DB1_USER}
      password: !ENV ${DB1_PASS}
      database: dc_db_1
metrics:
  - name: count_of_products
    metric_type: row_count
    resource: postgres.products
    validation:
      threshold: "> 0 & < 1000"
  - name: count_of_products
    metric_type: row_count
    resource: postgres.products
    validation:
      threshold: "> 0 & < 500"
  - name: max_product_price_in_india
    metric_type: max
    resource: postgres.products.price
    filters:
      where: "country_code = 'IN'"
    validation:
      threshold: "< 190"
```

## Type of change

Delete irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Locally Tested