### PR TITLE
refactor: changed input configuration from metric_type to type

### DIFF
--- a/datachecks/core/configuration/configuration_parser.py
+++ b/datachecks/core/configuration/configuration_parser.py
@@ -160,15 +160,13 @@ def parse_metric_configurations(
     metric_configurations: Dict[str, MetricConfiguration] = {}
 
     for metric_yaml_configuration in metric_yaml_configurations:
-        metric_type = MetricsType(metric_yaml_configuration["metric_type"].lower())
+        metric_type = MetricsType(metric_yaml_configuration["type"].lower())
 
         if metric_type == MetricsType.COMBINED:
             expression_str = metric_yaml_configuration["expression"]
             metric_configuration = MetricConfiguration(
                 name=metric_yaml_configuration["name"],
-                metric_type=MetricsType(
-                    metric_yaml_configuration["metric_type"].lower()
-                ),
+                metric_type=MetricsType(metric_yaml_configuration["type"].lower()),
                 expression=expression_str,
             )
         else:
@@ -180,9 +178,7 @@ def parse_metric_configurations(
 
             metric_configuration = MetricConfiguration(
                 name=metric_yaml_configuration["name"],
-                metric_type=MetricsType(
-                    metric_yaml_configuration["metric_type"].lower()
-                ),
+                metric_type=MetricsType(metric_yaml_configuration["type"].lower()),
                 resource=_metric_resource_parser(
                     resource_str=resource_str,
                     data_source_type=data_source_configuration.type,

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,7 +12,9 @@ Below we are installing the package with the **postgres extra**, which is requir
 ```bash
 pip install 'datachecks[postgres]' -U
 ```
+
 ## Quick Setup of Database & Test Data
+
 > Ignore if you already have a PostgreSql setup
 
 ??? "Create a SQL file"
@@ -40,7 +42,6 @@ pip install 'datachecks[postgres]' -U
     ```
 
 ??? "Postgres Docker Compose file"
-
 
     Create a `docker-compose.yml` for postgres:
 
@@ -89,12 +90,12 @@ data_sources:
       database: dcs_demo
 metrics:
   - name: count_of_products
-    metric_type: row_count
+    type: row_count
     resource: product_db.products
     validation:
       threshold: "> 0 & < 1000"
   - name: max_product_price_in_india
-    metric_type: max
+    type: max
     resource: product_db.products.price
     filters:
       where: "country_code = 'IN'"
@@ -124,6 +125,7 @@ This html report can be shared with the team.
 ```bash
 datachecks inspect --config-path ./dcs_config.yaml --html-report
 ```
+
 ![Getting Started](assets/datachecks_dashboard.png)
 
 ### Run Datachecks in Python


### PR DESCRIPTION
### Fixes/Implements #

## Description

Currently the type of metrics was `metric_type`, in this pull request it has been changed to `type`, to make it uniform with data_source name to address the issue #43.

![image](https://github.com/waterdipai/datachecks/assets/71203637/0d289c11-9d56-45c1-8e9a-c74cbab19edd)

This is the config file I have used
```yaml
data_sources:
  - name: postgres
    type: postgres
    connection:
      host: 127.0.0.1
      port: 5432
      username: postgres
      password: password
      database: postgres
      schema: public
metrics:
  - name: count_of_products
    type: row_count
    resource: postgres.products
    validation:
      threshold: "> 0 & < 1000"
  - name: count_of_products
    type: row_count
    resource: postgres.products
    validation:
      threshold: "> 0 & < 500"
  - name: max_product_price_in_india
    type: max
    resource: postgres.products.price
    filters:
      where: "country_code = 'IN'"
    validation:
      threshold: "< 190"
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Locally Tested