### PR TITLE
fixed duplicate datasource names bug

### DIFF
--- a/datachecks/core/configuration/configuration_parser.py
+++ b/datachecks/core/configuration/configuration_parser.py
@@ -51,6 +51,17 @@ CONDITION_TYPE_MAPPING = {
 def parse_data_source_yaml_configurations(
     data_source_yaml_configurations: List[Dict],
 ) -> Dict[str, DataSourceConfiguration]:
+    data_sources_names = []
+    duplicate_names = []
+    for data_source_yaml_configuration in data_source_yaml_configurations:
+        if data_source_yaml_configuration["name"] not in data_sources_names:
+            data_sources_names.append(data_source_yaml_configuration["name"])
+        else:
+            duplicate_names.append(data_source_yaml_configuration["name"])
+    if len(duplicate_names) != 0:
+        raise DataChecksConfigurationError(
+            f"Duplicate datasource names found : {duplicate_names}"
+        )
     data_source_configurations: Dict[str, DataSourceConfiguration] = {}
     for data_source_yaml_configuration in data_source_yaml_configurations:
         name_ = data_source_yaml_configuration["name"]


### PR DESCRIPTION
### Fixes/Implements #105 

## Description

Fixed the bug where duplicate datasource names were not detected.  This update generates an error and shows the names of the duplicate keys

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Locally Tested
- [x] Needs Testing From Production