### PR TITLE
fixed duplicate metric names bug

### DIFF
--- a/datachecks/core/configuration/configuration_parser.py
+++ b/datachecks/core/configuration/configuration_parser.py
@@ -51,6 +51,17 @@ CONDITION_TYPE_MAPPING = {
 def parse_data_source_yaml_configurations(
     data_source_yaml_configurations: List[Dict],
 ) -> Dict[str, DataSourceConfiguration]:
+    data_sources_names = []
+    duplicate_names = []
+    for data_source_yaml_configuration in data_source_yaml_configurations:
+        if data_source_yaml_configuration["name"] not in data_sources_names:
+            data_sources_names.append(data_source_yaml_configuration["name"])
+        else:
+            duplicate_names.append(data_source_yaml_configuration["name"])
+    if len(duplicate_names) != 0:
+        raise DataChecksConfigurationError(
+            f"Duplicate datasource names found : {duplicate_names}"
+        )
     data_source_configurations: Dict[str, DataSourceConfiguration] = {}
     for data_source_yaml_configuration in data_source_yaml_configurations:
         name_ = data_source_yaml_configuration["name"]

--- a/datachecks/core/configuration/configuration_parser.py
+++ b/datachecks/core/configuration/configuration_parser.py
@@ -51,17 +51,6 @@ CONDITION_TYPE_MAPPING = {
 def parse_data_source_yaml_configurations(
     data_source_yaml_configurations: List[Dict],
 ) -> Dict[str, DataSourceConfiguration]:
-    data_sources_names = []
-    duplicate_names = []
-    for data_source_yaml_configuration in data_source_yaml_configurations:
-        if data_source_yaml_configuration["name"] not in data_sources_names:
-            data_sources_names.append(data_source_yaml_configuration["name"])
-        else:
-            duplicate_names.append(data_source_yaml_configuration["name"])
-    if len(duplicate_names) != 0:
-        raise DataChecksConfigurationError(
-            f"Duplicate datasource names found : {duplicate_names}"
-        )
     data_source_configurations: Dict[str, DataSourceConfiguration] = {}
     for data_source_yaml_configuration in data_source_yaml_configurations:
         name_ = data_source_yaml_configuration["name"]
@@ -193,8 +182,14 @@ def parse_metric_configurations(
     data_source_configurations: Dict[str, DataSourceConfiguration],
     metric_yaml_configurations: List[Dict],
 ) -> Dict[str, MetricConfiguration]:
+    metrics_names = []
+    for metric_yaml_configuration in metric_yaml_configurations:
+        if metric_yaml_configuration["name"] in metrics_names:
+            raise DataChecksConfigurationError(
+                f"Duplicate metric names found: {metric_yaml_configuration['name']}"
+            )
+        metrics_names.append(metric_yaml_configuration["name"])
     metric_configurations: Dict[str, MetricConfiguration] = {}
-
     for metric_yaml_configuration in metric_yaml_configurations:
         metric_type = MetricsType(metric_yaml_configuration["metric_type"].lower())
 

--- a/tests/core/configuration/test_configuration.py
+++ b/tests/core/configuration/test_configuration.py
@@ -295,3 +295,39 @@ def test_should_throw_exception_on_invalid_storage_config():
         assert str(e).startswith(
             "Failed to parse configuration: path should be provided for local file storage configuration"
         )
+
+
+def test_should_throw_exception_on_duplicate_metric_names():
+    yaml_string = """
+        data_sources:
+          - name: "test"
+            type: "postgres"
+            connection:
+              host: "localhost"
+              port: 5421
+              username: postgres
+              password: postgres
+              database: dcs_db
+              schema: public
+        metrics:
+          - name: postgres_avg_price
+            metric_type: avg
+            resource: iris.dcs_iris.sepal_length
+            validation:
+              threshold: "> 0 & < 1000"
+
+          - name: postgres_min_price
+            metric_type: min
+            resource: iris.dcs_iris.sepal_length
+
+          - name: postgres_min_price
+            metric_type: max
+            resource: iris.dcs_iris.sepal_length
+        """
+
+    try:
+        configuration = load_configuration_from_yaml_str(yaml_string)
+    except Exception as e:
+        assert str(e).startswith(
+            "Failed to parse configuration: Duplicate metric names found"
+        )


### PR DESCRIPTION
### Fixes/Implements #106

## Description

Fixed the bug where duplicate metric names were not detected. This update generates an error and shows the names of the duplicate metric keys

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Locally Tested
- [x] Needs Testing From Production