### PR TITLE
fix: duplicate metric names

### DIFF
--- a/datachecks/core/configuration/configuration_parser.py
+++ b/datachecks/core/configuration/configuration_parser.py
@@ -189,8 +189,14 @@ def parse_metric_configurations(
     data_source_configurations: Dict[str, DataSourceConfiguration],
     metric_yaml_configurations: List[Dict],
 ) -> Dict[str, MetricConfiguration]:
+    metric_names = []
+    for metric_yaml_configuration in metric_yaml_configurations:
+        if metric_yaml_configuration["name"] in metric_names:
+            raise DataChecksConfigurationError(
+                f"Duplicate metric names found: {metric_yaml_configuration['name']}"
+            )
+        metric_names.append(metric_yaml_configuration["name"])
     metric_configurations: Dict[str, MetricConfiguration] = {}
-
     for metric_yaml_configuration in metric_yaml_configurations:
         metric_type = MetricsType(metric_yaml_configuration["metric_type"].lower())
 

--- a/tests/core/configuration/test_configuration.py
+++ b/tests/core/configuration/test_configuration.py
@@ -326,3 +326,39 @@ def test_should_throw_exception_on_duplicate_datasource_names():
         assert str(e).startswith(
             "Failed to parse configuration: Duplicate datasource names found"
         )
+
+
+def test_should_throw_exception_on_duplicate_metric_names():
+    yaml_string = """
+        data_sources:
+          - name: "test"
+            type: "postgres"
+            connection:
+              host: "localhost"
+              port: 5421
+              username: postgres
+              password: postgres
+              database: dcs_db
+              schema: public
+        metrics:
+          - name: postgres_avg_price
+            metric_type: avg
+            resource: iris.dcs_iris.sepal_length
+            validation:
+              threshold: "> 0 & < 1000"
+
+          - name: postgres_min_price
+            metric_type: min
+            resource: iris.dcs_iris.sepal_length
+
+          - name: postgres_min_price
+            metric_type: max
+            resource: iris.dcs_iris.sepal_length
+        """
+
+    try:
+        configuration = load_configuration_from_yaml_str(yaml_string)
+    except Exception as e:
+        assert str(e).startswith(
+            "Failed to parse configuration: Duplicate metric names found"
+        )


### PR DESCRIPTION
### Fixes/Implements #106 

## Description

Fixed the bug where duplicate metric names were not detected. This update generates an error and shows the names of the duplicate metrics

## Type of change

Delete irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Locally Tested
- [x] Needs Testing From Production