### PR TITLE
refactor: postgres_example_config data sources name iris_pgsql to iris

### DIFF
--- a/examples/configurations/example_postgres_config.yaml
+++ b/examples/configurations/example_postgres_config.yaml
@@ -1,6 +1,6 @@
 # Data sources to query
 data_sources:
-  - name: iris_pgsql
+  - name: iris
     type: postgres
     connection:
       host: 127.0.0.1
@@ -128,7 +128,6 @@ metrics:
     resource: iris.dcs_iris.sepal_length
     filters:
       where: "species = 'versicolor'"
-
 storage:
   type: local_file|s3|elastic|postgres|clickhouse
   params:


### PR DESCRIPTION
- `iris_pgsql` to `iris`

## Description
 In `examples\configurations\example_postgres_config.yaml`  datasources name was mentioned `iris_pgsql` which should be `iris`