### PR TITLE
refactor: example configurations suffixed with data sources type

### DIFF
--- a/examples/configurations/example_bigquery_config.yaml
+++ b/examples/configurations/example_bigquery_config.yaml
@@ -1,6 +1,6 @@
 # Data sources to query
 data_sources:
-  - name: iris
+  - name: iris_bigquery
     type: bigquery
     connection:
       project: !ENV ${GOOGLE_PROJECT_ID}
@@ -10,46 +10,46 @@ metrics:
   # Numeric Metrics - bigquery
   - name: bigquery_avg_price
     metric_type: avg
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_bigquery.dcs_iris.sepal_length
 
   - name: bigquery_min_price
     metric_type: min
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_bigquery.dcs_iris.sepal_length
 
   - name: bigquery_max_price
     metric_type: max
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_bigquery.dcs_iris.sepal_length
 
   - name: bigquery_variance_price
     metric_type: variance
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_bigquery.dcs_iris.sepal_length
 
   # Uniqueness Metrics - bigquery
   - name: bigquery_distinct_count_price
     metric_type: distinct_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_bigquery.dcs_iris.sepal_length
 
   - name: bigquery_duplicate_count_price
     metric_type: duplicate_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_bigquery.dcs_iris.sepal_length
 
   # Completeness Metrics - bigquery
   - name: bigquery_null_count_price
     metric_type: null_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_bigquery.dcs_iris.sepal_length
 
   - name: bigquery_empty_string_count_price
     metric_type: empty_string_count
-    resource: iris.dcs_iris.species
+    resource: iris_bigquery.dcs_iris.species
 
   # Reliability Metrics - bigquery
   - name: bigquery_row_count
     metric_type: row_count
-    resource: iris.dcs_iris
+    resource: iris_bigquery.dcs_iris
 
   - name: bigquery_freshness
     metric_type: freshness
-    resource: iris.dcs_iris.timestamp
+    resource: iris_bigquery.dcs_iris.timestamp
 
   # Combined Metrics - bigquery
   - name: bigquery_combined_div
@@ -87,60 +87,60 @@ metrics:
   # With Filters
   - name: bigquery_avg_price_with_filter
     metric_type: avg
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_bigquery.dcs_iris.sepal_length
     filters:
       where: 'species = "setosa"'
 
   - name: bigquery_max_price_with_filter
     metric_type: max
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_bigquery.dcs_iris.sepal_length
     filters:
       where: 'species = "setosa"'
 
   - name: bigquery_min_price_with_filter
     metric_type: min
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_bigquery.dcs_iris.sepal_length
     filters:
       where: 'species = "setosa"'
 
   - name: bigquery_variance_price_with_filter
     metric_type: variance
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_bigquery.dcs_iris.sepal_length
     filters:
       where: 'species = "setosa"'
 
   - name: bigquery_distinct_count_price_with_filter
     metric_type: distinct_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_bigquery.dcs_iris.sepal_length
     filters:
       where: 'species = "setosa"'
 
   - name: bigquery_duplicate_count_price_with_filter
     metric_type: duplicate_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_bigquery.dcs_iris.sepal_length
     filters:
       where: 'species = "setosa"'
 
   - name: bigquery_null_count_price_with_filter
     metric_type: null_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_bigquery.dcs_iris.sepal_length
     filters:
       where: 'species = "setosa"'
 
   - name: bigquery_empty_string_count_price_with_filter
     metric_type: empty_string_count
-    resource: iris.dcs_iris.species
+    resource: iris_bigquery.dcs_iris.species
     filters:
       where: 'species = "setosa"'
 
   - name: bigquery_row_count_with_filter
     metric_type: row_count
-    resource: iris.dcs_iris
+    resource: iris_bigquery.dcs_iris
     filters:
       where: 'species = "setosa"'
 
   - name: bigquery_freshness_with_filter
     metric_type: freshness
-    resource: iris.dcs_iris.timestamp
+    resource: iris_bigquery.dcs_iris.timestamp
     filters:
       where: 'species = "setosa"'

--- a/examples/configurations/example_databricks_config.yaml
+++ b/examples/configurations/example_databricks_config.yaml
@@ -1,6 +1,6 @@
 # Data sources to query
 data_sources:
-  - name: iris
+  - name: iris_databricks
     type: databricks
     connection:
       host: !ENV ${DATABRICKS_HOST}
@@ -13,50 +13,50 @@ metrics:
   # Numeric Metrics - Databricks
   - name: databricks_avg_price
     metric_type: avg
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_databricks.dcs_iris.sepal_length
 
   - name: databricks_min_price
     metric_type: min
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_databricks.dcs_iris.sepal_length
 
   - name: databricks_max_price
     metric_type: max
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_databricks.dcs_iris.sepal_length
 
   - name: databricks_variance_price
     metric_type: variance
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_databricks.dcs_iris.sepal_length
 
   # Uniqueness Metrics - Databricks
   - name: databricks_distinct_count_price
     metric_type: distinct_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_databricks.dcs_iris.sepal_length
 
   - name: databricks_duplicate_count_price
     metric_type: duplicate_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_databricks.dcs_iris.sepal_length
 
   # Completeness Metrics - Databricks
   - name: databricks_null_count_price
     metric_type: null_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_databricks.dcs_iris.sepal_length
 
   - name: databricks_null_percentage_price
     metric_type: null_percentage
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_databricks.dcs_iris.sepal_length
 
   - name: databricks_empty_string_count_price
     metric_type: empty_string_count
-    resource: iris.dcs_iris.species
+    resource: iris_databricks.dcs_iris.species
 
   # Reliability Metrics - Databricks
   - name: databricks_row_count
     metric_type: row_count
-    resource: iris.dcs_iris
+    resource: iris_databricks.dcs_iris
 
   - name: databricks_freshness
     metric_type: freshness
-    resource: iris.dcs_iris.timestamp
+    resource: iris_databricks.dcs_iris.timestamp
 
   # Combined Metrics - Databricks
   - name: databricks_combined_div
@@ -94,42 +94,42 @@ metrics:
   # With Filters
   - name: databricks_avg_price_with_filter
     metric_type: avg
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_databricks.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: databricks_avg_price_with_filter
     metric_type: avg
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_databricks.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: databricks_max_price_with_filter
     metric_type: max
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_databricks.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: databricks_min_price_with_filter
     metric_type: min
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_databricks.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: databricks_variance_price_with_filter
     metric_type: variance
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_databricks.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: databricks_distinct_count_price_with_filter
     metric_type: distinct_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_databricks.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: databricks_duplicate_count_price_with_filter
     metric_type: duplicate_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_databricks.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'

--- a/examples/configurations/example_elasticsearch_config.yaml
+++ b/examples/configurations/example_elasticsearch_config.yaml
@@ -1,6 +1,6 @@
 # Data sources to query
 data_sources:
-  - name: iris
+  - name: iris_elasticsearch
     type: elasticsearch
     connection:
       host: 127.0.0.1
@@ -12,50 +12,50 @@ metrics:
   # Numeric Metrics - ElasticSearch
   - name: elasticsearch_avg_price
     metric_type: avg
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_elasticsearch.dcs_iris.sepal_length
 
   - name: elasticsearch_min_price
     metric_type: min
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_elasticsearch.dcs_iris.sepal_length
 
   - name: elasticsearch_max_price
     metric_type: max
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_elasticsearch.dcs_iris.sepal_length
 
   - name: elasticsearch_variance_price
     metric_type: variance
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_elasticsearch.dcs_iris.sepal_length
 
   # Uniqueness Metrics - ElasticSearch
   - name: elasticsearch_distinct_count_price
     metric_type: distinct_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_elasticsearch.dcs_iris.sepal_length
 
   - name: elasticsearch_duplicate_count_price
     metric_type: duplicate_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_elasticsearch.dcs_iris.sepal_length
 
   # Completeness Metrics - ElasticSearch
   - name: elasticsearch_null_count_price
     metric_type: null_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_elasticsearch.dcs_iris.sepal_length
 
   - name: elasticsearch_null_percentage_price
     metric_type: null_percentage
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_elasticsearch.dcs_iris.sepal_length
 
   - name: elasticsearch_empty_string_count_price
     metric_type: empty_string_count
-    resource: iris.dcs_iris.species
+    resource: iris_elasticsearch.dcs_iris.species
 
   # Reliability Metrics - ElasticSearch
   - name: elasticsearch_document_count
     metric_type: document_count
-    resource: iris.dcs_iris
+    resource: iris_elasticsearch.dcs_iris
 
   - name: elasticsearch_freshness
     metric_type: freshness
-    resource: iris.dcs_iris.timestamp
+    resource: iris_elasticsearch.dcs_iris.timestamp
 
   # Combined Metrics - ElasticSearch
   - name: elasticsearch_combined_div
@@ -94,41 +94,41 @@ metrics:
 
   - name: elasticsearch_max_price_with_filter
     metric_type: max
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_elasticsearch.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: elasticsearch_min_price_with_filter
     metric_type: min
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_elasticsearch.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: elasticsearch_avg_price_with_filter
     metric_type: avg
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_elasticsearch.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: elasticsearch_max_price_with_filter
     metric_type: max
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_elasticsearch.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: elasticsearch_min_price_with_filter
     metric_type: min
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_elasticsearch.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
   - name: elasticsearch_variance_price_with_filter
     metric_type: variance
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_elasticsearch.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: elasticsearch_distinct_count_price_with_filter
     metric_type: distinct_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_elasticsearch.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'

--- a/examples/configurations/example_mysql_config.yaml
+++ b/examples/configurations/example_mysql_config.yaml
@@ -1,6 +1,6 @@
 # Data sources to query
 data_sources:
-  - name: iris
+  - name: iris_mysql
     type: mysql
     connection:
       host: 127.0.0.1
@@ -12,50 +12,50 @@ metrics:
   # Numeric Metrics
   - name: mysql_avg_price
     metric_type: avg
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_mysql.dcs_iris.sepal_length
 
   - name: mysql_min_price
     metric_type: min
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_mysql.dcs_iris.sepal_length
 
   - name: mysql_max_price
     metric_type: max
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_mysql.dcs_iris.sepal_length
 
   - name: mysql_variance_price
     metric_type: variance
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_mysql.dcs_iris.sepal_length
 
   # Uniqueness Metrics
   - name: mysql_distinct_count_price
     metric_type: distinct_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_mysql.dcs_iris.sepal_length
 
   - name: mysql_duplicate_count_price
     metric_type: duplicate_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_mysql.dcs_iris.sepal_length
 
   # Completeness Metrics
   - name: mysql_null_count_price
     metric_type: null_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_mysql.dcs_iris.sepal_length
 
   - name: mysql_null_percentage_price
     metric_type: null_percentage
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_mysql.dcs_iris.sepal_length
 
   - name: mysql_empty_string_count_price
     metric_type: empty_string_count
-    resource: iris.dcs_iris.species
+    resource: iris_mysql.dcs_iris.species
 
   # Reliability Metrics
   - name: mysql_row_count
     metric_type: row_count
-    resource: iris.dcs_iris
+    resource: iris_mysql.dcs_iris
 
   - name: mysql_freshness
     metric_type: freshness
-    resource: iris.dcs_iris.timestamp
+    resource: iris_mysql.dcs_iris.timestamp
 
   # Combined Metrics
   - name: mysql_combined_div
@@ -93,36 +93,36 @@ metrics:
   # Filtered Metrics
   - name: mysql_max_price_filtered
     metric_type: max
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_mysql.dcs_iris.sepal_length
     filters:
       where: "species = 'versicolor'"
 
   - name: mysql_avg_price_with_filter
     metric_type: avg
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_mysql.dcs_iris.sepal_length
     filters:
       where: "species = 'versicolor'"
 
   - name: mysql_max_price_with_filter
     metric_type: max
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_mysql.dcs_iris.sepal_length
     filters:
       where: "species = 'versicolor'"
 
   - name: mysql_min_price_with_filter
     metric_type: min
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_mysql.dcs_iris.sepal_length
     filters:
       where: "species = 'versicolor'"
 
   - name: mysql_distinct_count_price_with_filter
     metric_type: distinct_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_mysql.dcs_iris.sepal_length
     filters:
       where: "species = 'versicolor'"
 
   - name: mysql_empty_string_count_price_with_filter
     metric_type: empty_string_count
-    resource: iris.dcs_iris.species
+    resource: iris_mysql.dcs_iris.species
     filters:
       where: "species = 'versicolor'"

--- a/examples/configurations/example_opensearch_config.yaml
+++ b/examples/configurations/example_opensearch_config.yaml
@@ -1,6 +1,6 @@
 # Data sources to query
 data_sources:
-  - name: iris
+  - name: iris_opensearch
     type: opensearch
     connection:
       host: 127.0.0.1
@@ -12,50 +12,50 @@ metrics:
   # Numeric Metrics - OpenSearch
   - name: opensearch_avg_price
     metric_type: avg
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_opensearch.dcs_iris.sepal_length
 
   - name: opensearch_min_price
     metric_type: min
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_opensearch.dcs_iris.sepal_length
 
   - name: opensearch_max_price
     metric_type: max
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_opensearch.dcs_iris.sepal_length
 
   - name: opensearch_variance_price
     metric_type: variance
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_opensearch.dcs_iris.sepal_length
 
   # Uniqueness Metrics - OpenSearch
   - name: opensearch_distinct_count_price
     metric_type: distinct_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_opensearch.dcs_iris.sepal_length
 
   - name: opensearch_duplicate_count_price
     metric_type: duplicate_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_opensearch.dcs_iris.sepal_length
 
   # Completeness Metrics - OpenSearch
   - name: opensearch_null_count_price
     metric_type: null_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_opensearch.dcs_iris.sepal_length
 
   - name: opensearch_null_percentage_price
     metric_type: null_percentage
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_opensearch.dcs_iris.sepal_length
 
   - name: opensearch_empty_string_count_price
     metric_type: empty_string_count
-    resource: iris.dcs_iris.species
+    resource: iris_opensearch.dcs_iris.species
 
   # Reliability Metrics - OpenSearch
   - name: opensearch_document_count
     metric_type: document_count
-    resource: iris.dcs_iris
+    resource: iris_opensearch.dcs_iris
 
   - name: opensearch_freshness
     metric_type: freshness
-    resource: iris.dcs_iris.timestamp
+    resource: iris_opensearch.dcs_iris.timestamp
 
   # Combined Metrics - OpenSearch
   - name: opensearch_combined_div
@@ -93,42 +93,42 @@ metrics:
   # With Filters
   - name: opensearch_avg_price_with_filter
     metric_type: avg
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_opensearch.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: opensearch_max_price_with_filter
     metric_type: max
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_opensearch.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: opensearch_min_price_with_filter
     metric_type: min
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_opensearch.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: opensearch_distinct_count_price_with_filter
     metric_type: distinct_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_opensearch.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: opensearch_duplicate_count_price_with_filter
     metric_type: duplicate_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_opensearch.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: opensearch_null_count_price_with_filter
     metric_type: null_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_opensearch.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'
 
   - name: opensearch_null_percentage_price_with_filter
     metric_type: null_percentage
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_opensearch.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'

--- a/examples/configurations/example_postgres_config.yaml
+++ b/examples/configurations/example_postgres_config.yaml
@@ -1,4 +1,4 @@
-# Data sources to query
+# Data sources to queryiris_pgsql
 data_sources:
   - name: iris_pgsql
     type: postgres
@@ -13,54 +13,54 @@ metrics:
   # Numeric Metrics
   - name: sepal_length_avg_price
     metric_type: avg
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_pgsql.dcs_iris.sepal_length
     validation:
       threshold: "> 0 & < 1000"
 
   - name: postgres_min_price
     metric_type: min
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_pgsql.dcs_iris.sepal_length
 
   - name: postgres_max_price
     metric_type: max
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_pgsql.dcs_iris.sepal_length
 
   - name: postgres_variance_price
     metric_type: variance
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_pgsql.dcs_iris.sepal_length
 
   # Uniqueness Metrics
   - name: postgres_distinct_count_price
     metric_type: distinct_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_pgsql.dcs_iris.sepal_length
 
   - name: postgres_duplicate_count_price
     metric_type: duplicate_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_pgsql.dcs_iris.sepal_length
 
   # Completeness Metrics
   - name: postgres_null_count_price
     metric_type: null_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_pgsql.dcs_iris.sepal_length
 
   - name: postgres_null_percentage_price
     metric_type: null_percentage
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_pgsql.dcs_iris.sepal_length
 
   - name: postgres_empty_string_count_price
     metric_type: empty_string_count
-    resource: iris.dcs_iris.species
+    resource: iris_pgsql.dcs_iris.species
 
   # Reliability Metrics
   - name: postgres_row_count
     metric_type: row_count
-    resource: iris.dcs_iris
+    resource: iris_pgsql.dcs_iris
     validation:
       threshold: "> 100"
 
   - name: postgres_freshness
     metric_type: freshness
-    resource: iris.dcs_iris.timestamp
+    resource: iris_pgsql.dcs_iris.timestamp
     validation:
       threshold: ">-5000"
 
@@ -101,34 +101,33 @@ metrics:
 
   - name: postgres_avg_price_filtered
     metric_type: avg
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_pgsql.dcs_iris.sepal_length
     filters:
       where: "species = 'versicolor'"
 
   - name: postgres_min_price_filtered
     metric_type: min
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_pgsql.dcs_iris.sepal_length
     filters:
       where: "species = 'versicolor'"
 
   - name: postgres_max_price_with_filter
     metric_type: max
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_pgsql.dcs_iris.sepal_length
     filters:
       where: "species = 'versicolor'"
 
   - name: postgres_min_price_with_filter
     metric_type: min
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_pgsql.dcs_iris.sepal_length
     filters:
       where: "species = 'versicolor'"
 
   - name: postgres_distinct_count_price_with_filter
     metric_type: distinct_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_pgsql.dcs_iris.sepal_length
     filters:
       where: "species = 'versicolor'"
-
 storage:
   type: local_file|s3|elastic|postgres|clickhouse
   params:

--- a/examples/configurations/example_redshift_config.yaml
+++ b/examples/configurations/example_redshift_config.yaml
@@ -13,50 +13,50 @@ metrics:
   # Numeric Metrics - RedShift
   - name: redshift_avg_price
     metric_type: avg
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_redshift.dcs_iris.sepal_length
 
   - name: redshift_min_price
     metric_type: min
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_redshift.dcs_iris.sepal_length
 
   - name: redshift_max_price
     metric_type: max
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_redshift.dcs_iris.sepal_length
 
   - name: redshift_variance_price
     metric_type: variance
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_redshift.dcs_iris.sepal_length
 
   # Uniqueness Metrics - RedShift
   - name: redshift_distinct_count_price
     metric_type: distinct_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_redshift.dcs_iris.sepal_length
     validation:
       threshold: "<= 36"
 
   - name: redshift_duplicate_count_price
     metric_type: duplicate_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_redshift.dcs_iris.sepal_length
     validation:
       threshold: ">= 9 & >= 36"
 
   # Completeness Metrics - RedShift
   - name: redshift_null_count_price
     metric_type: null_count
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_redshift.dcs_iris.sepal_length
 
   - name: redshift_null_percentage_price
     metric_type: null_percentage
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_redshift.dcs_iris.sepal_length
 
   - name: redshift_empty_string_count_price
     metric_type: empty_string_count
-    resource: iris.dcs_iris.species
+    resource: iris_redshift.dcs_iris.species
 
   # Reliability Metrics - RedShift
   - name: redshift_row_count
     metric_type: row_count
-    resource: iris.dcs_iris
+    resource: iris_redshift.dcs_iris
 
   # Combined Metrics - RedShift
   - name: redshift_combined_div
@@ -99,6 +99,6 @@ metrics:
   # With Filters
   - name: redshift_avg_price_with_filter
     metric_type: avg
-    resource: iris.dcs_iris.sepal_length
+    resource: iris_redshift.dcs_iris.sepal_length
     filters:
       where: '{ "match": { "species": "versicolor" } }'


### PR DESCRIPTION
## Description
- In `examples\configurations` - data_sources name is suffixed with type of database.
