### PR TITLE
fix(typo): renamed datasource iris to iris_pgsql

### DIFF
--- a/examples/configurations/example_postgres_config.yaml
+++ b/examples/configurations/example_postgres_config.yaml
@@ -1,6 +1,6 @@
-# Data sources to queryiris_pgsql
+# Data sources to query
 data_sources:
-  - name: iris
+  - name: iris_pgsql
     type: postgres
     connection:
       host: 127.0.0.1


### PR DESCRIPTION
### Fixes/Implements #
Renamed the datasource name from iris to iris_pgsql inside the configuration file example_postgres_config.yaml 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)